### PR TITLE
開発環境作成設定の追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.bundle
+.vagrant

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # BitKidsServer
+
+## 開発者向け情報
+
+### 開発環境の準備
+
+1. 下記のソフトウェアがインストールされていることを確認します
+
+    * Vagrant 1.8 以上
+
+2. リポジトリを clone します
+
+       git clone https://github.com/BitKids/BitKidsServer
+
+3. clone してできたディレクトリに移動します
+
+       cd BitKidsServer
+
+4. 下記のコマンドを実行して、開発用仮想環境を作成します
+
+       vagrant up

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,92 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.define :bitkids_dev do |bitkids_dev|
+    bitkids_dev.vm.network "private_network", ip: "192.168.33.30"
+  end
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+  config.vm.define :bitkids_dev do |bitkids_dev|
+    bitkids_dev.vm.provider :virtualbox do |vb|
+      vb.name = "bitkids-dev"
+      vb.memory = "2048"
+    end
+  end
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   sudo apt-get update
+  #   sudo apt-get install -y apache2
+  # SHELL
+  config.vm.define :bitkids_dev do |bitkids_dev|
+    bitkids_dev.vm.provision :shell, inline: <<-SHELL
+      sudo apt-get update
+      sudo apt-get install -y python-dev python-pip
+      sudo pip install ansible==1.9.4
+    SHELL
+    bitkids_dev.vm.provision :ansible_local do |ansible|
+      ansible.provisioning_path = "/vagrant/vagrant-ansible"
+      ansible.playbook = "bitkids_dev.yml"
+      ansible.install = false
+    end
+  end
+end

--- a/vagrant-ansible/bitkids_dev.yml
+++ b/vagrant-ansible/bitkids_dev.yml
@@ -1,0 +1,14 @@
+---
+- name: build bitkids development environment
+  hosts: bitkids_dev
+  connection: local
+  sudo: yes
+  roles:
+    - common
+    - ruby
+    - nodejs
+    - rails
+    - mysql
+    - redis
+    - nginx
+    - app

--- a/vagrant-ansible/roles/app/tasks/main.yml
+++ b/vagrant-ansible/roles/app/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: "install Puma's Upstart service scripts"
+  template: src=roles/app/templates/{{ item }}.j2 dest=/etc/init/{{ item }}
+  with_items:
+    - puma.conf
+    - puma-manager.conf
+
+- name: copy Puma configuration for starting applications
+  template: src=roles/app/templates/etc-puma.conf.j2 dest=/etc/puma.conf

--- a/vagrant-ansible/roles/app/templates/etc-puma.conf.j2
+++ b/vagrant-ansible/roles/app/templates/etc-puma.conf.j2
@@ -1,0 +1,2 @@
+{{ rbenv_home }}/{{ bitkids_api_appname }}
+{{ rbenv_home }}/{{ bitkids_ws_appname }}

--- a/vagrant-ansible/roles/app/templates/puma-manager.conf.j2
+++ b/vagrant-ansible/roles/app/templates/puma-manager.conf.j2
@@ -1,0 +1,31 @@
+# /etc/init/puma-manager.conf - manage a set of Pumas
+
+# This example config should work with Ubuntu 12.04+.  It
+# allows you to manage multiple Puma instances with
+# Upstart, Ubuntu's native service management tool.
+#
+# See puma.conf for how to manage a single Puma instance.
+#
+# Use "stop puma-manager" to stop all Puma instances.
+# Use "start puma-manager" to start all instances.
+# Use "restart puma-manager" to restart all instances.
+# Crazy, right?
+#
+
+description "Manages the set of puma processes"
+
+# This starts upon bootup and stops on shutdown
+start on runlevel [2345]
+stop on runlevel [06]
+
+# Set this to the number of Puma processes you want
+# to run on this machine
+env PUMA_CONF="/etc/puma.conf"
+
+pre-start script
+  for i in `cat $PUMA_CONF`; do
+    app=`echo $i | cut -d , -f 1`
+    logger -t "puma-manager" "Starting $app"
+    start puma app=$app
+  done
+end script

--- a/vagrant-ansible/roles/app/templates/puma.conf.j2
+++ b/vagrant-ansible/roles/app/templates/puma.conf.j2
@@ -1,0 +1,69 @@
+# /etc/init/puma.conf - Puma config
+
+# This example config should work with Ubuntu 12.04+.  It
+# allows you to manage multiple Puma instances with
+# Upstart, Ubuntu's native service management tool.
+#
+# See workers.conf for how to manage all Puma instances at once.
+#
+# Save this config as /etc/init/puma.conf then manage puma with:
+#   sudo start puma app=PATH_TO_APP
+#   sudo stop puma app=PATH_TO_APP
+#   sudo status puma app=PATH_TO_APP
+#
+# or use the service command:
+#   sudo service puma {start,stop,restart,status}
+#
+
+description "Puma Background Worker"
+
+# no "start on", we don't want to automatically start
+stop on (stopping puma-manager or runlevel [06])
+
+# change apps to match your deployment user if you want to use this as a less privileged user (recommended!)
+setuid {{ rbenv_user }}
+setgid {{ rbenv_user }}
+
+respawn
+respawn limit 3 30
+
+instance ${app}
+
+script
+# this script runs in /bin/sh by default
+# respawn as bash so we can source in rbenv/rvm
+# quoted heredoc to tell /bin/sh not to interpret
+# variables
+
+# source ENV variables manually as Upstart doesn't, eg:
+#. /etc/environment
+
+exec /bin/bash <<'EOT'
+  # set HOME to the setuid user's home, there doesn't seem to be a better, portable way
+  export HOME="$(eval echo ~$(id -un))"
+
+  if [ -d "/usr/local/rbenv/bin" ]; then
+    export PATH="/usr/local/rbenv/bin:/usr/local/rbenv/shims:$PATH"
+  elif [ -d "$HOME/.rbenv/bin" ]; then
+    export PATH="$HOME/.rbenv/bin:$HOME/.rbenv/shims:$PATH"
+  elif [ -f  /etc/profile.d/rvm.sh ]; then
+    source /etc/profile.d/rvm.sh
+  elif [ -f /usr/local/rvm/scripts/rvm ]; then
+    source /etc/profile.d/rvm.sh
+  elif [ -f "$HOME/.rvm/scripts/rvm" ]; then
+    source "$HOME/.rvm/scripts/rvm"
+  elif [ -f /usr/local/share/chruby/chruby.sh ]; then
+    source /usr/local/share/chruby/chruby.sh
+    if [ -f /usr/local/share/chruby/auto.sh ]; then
+      source /usr/local/share/chruby/auto.sh
+    fi
+    # if you aren't using auto, set your version here
+    # chruby 2.0.0
+  fi
+
+  cd $app
+  logger -t puma "Starting server: $app"
+
+  exec bundle exec puma -C config/puma.rb
+EOT
+end script

--- a/vagrant-ansible/roles/common/defaults/main.yml
+++ b/vagrant-ansible/roles/common/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+rbenv_user: vagrant
+rbenv_home: /home/vagrant
+ruby_version: 2.3.0
+rails_version: 5.0.0.beta3
+mysql_apt: "mysql-apt-config_0.6.0-1_all.deb"
+bitkids_api_appname: bitkids-api
+bitkids_ws_appname: bitkids-ws

--- a/vagrant-ansible/roles/common/tasks/main.yml
+++ b/vagrant-ansible/roles/common/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: upgrade packages
+  apt: upgrade=dist update_cache=yes
+
+- name: autoremove unused packages
+  shell: apt-get -y autoremove
+  register: autoremove_output
+  changed_when: "'The following packages will be REMOVED' in autoremove_output.stdout"
+
+- name: set Japanese timezone
+  replace: dest=/etc/timezone regexp='Etc/UTC' replace='Asia/Tokyo'
+  register: timezone_modified
+
+- name: reconfigure tzdata
+  shell: dpkg-reconfigure --frontend noninteractive tzdata
+  when: timezone_modified|changed

--- a/vagrant-ansible/roles/mysql/handlers/main.yml
+++ b/vagrant-ansible/roles/mysql/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart mysql
+  service: name=mysql state=restarted

--- a/vagrant-ansible/roles/mysql/tasks/main.yml
+++ b/vagrant-ansible/roles/mysql/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+- name: fetch MySQL official repository apt
+  get_url: "url=http://dev.mysql.com/get/{{ mysql_apt }} dest=/tmp/{{ mysql_apt }}"
+
+- name: debconf mysql-apt-config
+  debconf: name=mysql-apt-config question=mysql-apt-config/{{ item.key }} value={{ item.value }} vtype={{ item.vtype }}
+  with_items:
+    - { key: "repo-distro", value: "ubuntu", vtype: "string" }
+    - { key: "repo-codename", value: "trusty", vtype: "string" }
+    - { key: "select-server", value: "mysql-5.7", vtype: "string" }
+    - { key: "select-product", value: "Apply", vtype: "string" }
+
+- name: install MySQL official repository apt
+  apt: deb=/tmp/{{ mysql_apt }}
+  environment:
+    DEBIAN_FRONTEND: noninteractive
+
+- name: install MySQL and client development library
+  apt: name={{ item }} state=latest update_cache=yes
+  with_items:
+    - mysql-server
+    - libmysqlclient-dev
+
+- name: install python-mysqldb for configuring MySQL via Ansible
+  apt: name=python-mysqldb state=latest
+
+- name: start and enable MySQL service
+  service: name=mysql state=started enabled=yes
+
+- name: remove rbenv user from MySQL as workaround for issue between MySQL 5.7 and Ansible 1.9
+  mysql_user: name={{ rbenv_user }} state=absent
+
+- name: add rbenv user to MySQL w/o password
+  mysql_user: name={{ rbenv_user }} password="" priv="*.*:ALL,GRANT" state=present
+
+- name: copy MySQL custom configuration
+  template: src=roles/mysql/templates/custom.cnf.j2 dest=/etc/mysql/conf.d/custom.cnf
+  notify: restart mysql

--- a/vagrant-ansible/roles/mysql/templates/custom.cnf.j2
+++ b/vagrant-ansible/roles/mysql/templates/custom.cnf.j2
@@ -1,0 +1,3 @@
+[mysqld]
+
+log_timestamps = SYSTEM

--- a/vagrant-ansible/roles/nginx/handlers/main.yml
+++ b/vagrant-ansible/roles/nginx/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: reload nginx
+  service: name=nginx state=reloaded

--- a/vagrant-ansible/roles/nginx/tasks/main.yml
+++ b/vagrant-ansible/roles/nginx/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: fetch nginx apt signing key
+  apt_key: url=http://nginx.org/keys/nginx_signing.key state=present
+
+- name: copy nginx apt source.list
+  template: src=roles/nginx/templates/nginx.list.j2 dest=/etc/apt/sources.list.d/nginx.list
+
+- name: install nginx
+  apt: name=nginx state=latest update_cache=yes
+
+- name: start and enable nginx service
+  service: name=nginx state=started enabled=yes
+
+- name: copy nginx custom configuration
+  template: src=roles/nginx/templates/default.conf.j2 dest=/etc/nginx/conf.d/default.conf backup
+  notify: reload nginx

--- a/vagrant-ansible/roles/nginx/templates/default.conf.j2
+++ b/vagrant-ansible/roles/nginx/templates/default.conf.j2
@@ -1,0 +1,46 @@
+upstream api {
+    server unix:{{ rbenv_home }}/{{ bitkids_api_appname }}/tmp/sockets/puma.sock fail_timeout=0;
+}
+
+upstream ws {
+    server unix:{{ rbenv_home }}/{{ bitkids_ws_appname }}/tmp/sockets/puma.sock fail_timeout=0;
+}
+
+server {
+    listen       80;
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/log/host.access.log  main;
+
+    location /api/ {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $http_host;
+        #proxy_redirect   off;
+        proxy_pass       http://api/;
+    }
+
+    location /ws/ {
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+        proxy_http_version 1.1;
+        #proxy_redirect     off;
+        proxy_pass         http://ws/;
+    }
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/vagrant-ansible/roles/nginx/templates/nginx.list.j2
+++ b/vagrant-ansible/roles/nginx/templates/nginx.list.j2
@@ -1,0 +1,2 @@
+deb http://nginx.org/packages/mainline/ubuntu/ {{ ansible_distribution_release }} nginx
+deb-src http://nginx.org/packages/mainline/ubuntu/ {{ ansible_distribution_release }} nginx

--- a/vagrant-ansible/roles/nodejs/tasks/main.yml
+++ b/vagrant-ansible/roles/nodejs/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: install curl
+  apt: name=curl state=latest
+
+- name: check if Node.js source.list exists
+  stat: path=/etc/apt/sources.list.d/nodesource.list
+  register: node_source
+
+- name: prepare Node.js repository
+  shell: curl -sL https://deb.nodesource.com/setup_4.x | bash -
+  when: node_source.stat.isreg is not defined
+
+- name: install Node.js
+  apt: name=nodejs state=latest update_cache=yes

--- a/vagrant-ansible/roles/rails/tasks/main.yml
+++ b/vagrant-ansible/roles/rails/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: install bundler
+  sudo_user: "{{ rbenv_user }}"
+  gem: name=bundler state=present executable=~/.rbenv/shims/gem user_install=no
+
+- name: install packages on which rails depends
+  apt: name={{ item }} state=latest
+  with_items:
+    - libsqlite3-dev
+    - sqlite3
+
+- name: install rails
+  sudo_user: "{{ rbenv_user }}"
+  gem: name=rails version={{ rails_version }} state=present executable=~/.rbenv/shims/gem user_install=no

--- a/vagrant-ansible/roles/redis/tasks/main.yml
+++ b/vagrant-ansible/roles/redis/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: install Redis
+  apt: name=redis-server state=latest
+
+- name: start and enable Redis service
+  service: name=redis-server state=started enabled=yes

--- a/vagrant-ansible/roles/ruby/tasks/main.yml
+++ b/vagrant-ansible/roles/ruby/tasks/main.yml
@@ -1,0 +1,67 @@
+---
+- name: install git for cloning rbenv repository
+  apt: name={{ item }} state=latest
+  with_items:
+    - git-core
+
+- name: check if the user who will run rbenv exists to avoid override it in next step
+  shell: "grep -q {{ rbenv_user}} /etc/passwd"
+  register: user_exists
+  changed_when: False
+  ignore_errors: True
+
+- name: add the user who will run rbenv if it does not exist
+  user: name={{ rbenv_user }} home={{ rbenv_home }} comment="rbenv user"
+  when: user_exists|failed
+
+- name: clone rbenv from github
+  sudo_user: "{{ rbenv_user }}"
+  git: "repo=git://github.com/sstephenson/rbenv.git dest=~/.rbenv accept_hostkey=yes"
+
+- name: add rbenv path to .profile
+  sudo_user: "{{ rbenv_user }}"
+  lineinfile: dest=~/.profile line='export PATH="$HOME/.rbenv/bin:$PATH"'
+
+- name: add eval rbenv init to .profile
+  sudo_user: "{{ rbenv_user }}"
+  lineinfile: dest=~/.profile line='eval "$(rbenv init -)"'
+
+- name: clone ruby-build from github
+  sudo_user: "{{ rbenv_user }}"
+  git: "repo=git://github.com/sstephenson/ruby-build.git dest=~/.rbenv/plugins/ruby-build accept_hostkey=yes"
+
+- name: check if specific version of ruby is already installed
+  shell: "sudo -iu {{ rbenv_user }} rbenv versions | grep -q {{ ruby_version }}"
+  register: ruby_installed
+  changed_when: False
+  ignore_errors: True
+
+- name: "install dev packages for rbenv based on https://github.com/rbenv/ruby-build/wiki"
+  apt: name={{ item }} state=latest
+  with_items:
+    - autoconf
+    - bison
+    - build-essential
+    - libssl-dev
+    - libyaml-dev
+    - libreadline-dev
+    - zlib1g-dev
+    - libncurses-dev
+    - libffi-dev
+    - libgdbm3
+    - libgdbm-dev
+  when: ruby_installed|failed
+
+- name: install ruby
+  shell: "sudo -iu {{ rbenv_user }} rbenv install {{ ruby_version }}"
+  when: ruby_installed|failed
+
+- name: check current global ruby version
+  shell: "sudo -iu {{ rbenv_user }} rbenv version | grep -q {{ ruby_version }}"
+  register: ruby_selected
+  changed_when: False
+  ignore_errors: True
+
+- name: set global ruby version
+  shell: "sudo -iu {{ rbenv_user }} rbenv global {{ ruby_version }}"
+  when: ruby_selected|failed


### PR DESCRIPTION
サーバ側ソフトウェア開発者向けに、本番と同様な構成の開発用仮想環境を作成するための Vagrantfile と Ansible の定義ファイルを作成しました

Ansible は Vagrant の `ansible_local` 使っていますので、ホスト側にインストールされている必要はありません。 Vagrant 1.8 以上が動作する環境であれば作成ができるものと思います

作成したサーバでは主に `vagrant` ユーザーで作業できるようになっています

まずは形にしてみた状態ですので、こうした方がよいというアイデアなどあればどんどん指摘をお願いします
