### PR TITLE
Fix puma start up error

### DIFF
--- a/vagrant-ansible/roles/app/tasks/main.yml
+++ b/vagrant-ansible/roles/app/tasks/main.yml
@@ -9,4 +9,5 @@
   template: src=roles/app/templates/etc-puma.conf.j2 dest=/etc/puma.conf
 
 - name: create puma socket directory
+  become_user: "{{ rbenv_user }}"
   file: path=/tmp/sockets state=directory


### PR DESCRIPTION
先日指摘いただきました、 Vagrant を再初期化した時に Puma が起動しない問題ですが、すみません、 ansible 内で `/tmp/sockets` ディレクトリを作る場合に root ユーザーに sudo した形で作成されていて、実際にアプリケーションを起動するユーザーで作られていなかったことが原因らしいことに気がつきました。こちらはその修正となります。

すでに該当ディレクトリが root ユーザーで作成されてしまっている場合は、

```
sudo chown vagrant:vagrant /tmp/sockets
```

としてあげれば修正ができます
